### PR TITLE
support !Condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const yaml = require('js-yaml');
 module.exports = yaml.DEFAULT_SCHEMA.extend([
   require('./lib/and.js'),
   require('./lib/base64.js'),
+  require('./lib/condition.js'),
   require('./lib/equals.js'),
   require('./lib/findInMap.js'),
   require('./lib/getAtt.js'),

--- a/lib/condition.js
+++ b/lib/condition.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const yaml = require('js-yaml');
+
+const functionName = 'Fn::Condition'
+const yamlName = '!Condition'
+
+class Obj {
+  constructor (params) {
+    this[functionName] = params
+  }
+}
+
+const Type = new yaml.Type(yamlName, {
+  kind: 'scalar',
+  resolve: function (data) {
+    return typeof data === 'string'
+  },
+
+  construct: function (data) {
+    return new Obj(data)
+  },
+
+  instanceOf: Obj,
+
+  represent: function (obj) {
+    return obj[functionName]
+  }
+})
+
+module.exports = Type

--- a/test.js
+++ b/test.js
@@ -24,6 +24,12 @@ test('yaml parser should', function (t) {
   )
 
   t.deepLooseEqual(
+    yaml.load(`test: !Condition SomeString`, { schema }),
+    { test: { 'Fn::Condition': 'SomeString' } },
+    'parse !Condition'
+  )
+
+  t.deepLooseEqual(
     yaml.load(`test: !Equals [ 'a', 'b' ]`, { schema }),
     { test: { 'Fn::Equals': [ 'a', 'b' ]}},
     'parse !Equals'
@@ -143,6 +149,7 @@ test('yaml parser should', function (t) {
     - !And ['a', 'b', 'c']
     - !Base64 { Ref: LogicalId }
     - !Base64 string
+    - !Condition string
     - !Equals [ 'a', 'b' ]
     - !FindInMap [ "a", "b", "c" ]
     - !If ['a', 'b' ,'c' ]
@@ -171,6 +178,7 @@ test('yaml parser should', function (t) {
   - !Base64
     Ref: LogicalId
   - !Base64 string
+  - !Condition string
   - !Equals
     - a
     - b


### PR DESCRIPTION
Cloudformation supports a scalar `!Condition` directive that conditions can use to refer to other conditions. The documentation for it is a bit buried and doesn't show up in the table of contents of the [Condition intrinsic function docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-conditions.html) like you'd expect, but both that page (in [the `!And` usage example](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-and)) and the [Conditions syntax doc section on referencing conditions in other conditions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html#reference-conditions-in-other-conditions) note it.